### PR TITLE
Fix/batch size

### DIFF
--- a/eventlogger/main.go
+++ b/eventlogger/main.go
@@ -73,6 +73,9 @@ func HandleIndividualRecord(ctx context.Context, evt events.KinesisEventRecord) 
 
 func doBatchWrite(ctx context.Context, ddbClient *dynamodb.DynamoDB, tableName string, incomingRequests []*dynamodb.WriteRequest, recordCount int) error {
 	var putRequests []*dynamodb.WriteRequest
+	if recordCount == 0 { //if there are no records to commit then just return. This case can happen if we error out on the last record of a batch.
+		return nil
+	}
 	if recordCount < len(incomingRequests) {
 		putRequests = incomingRequests[0:recordCount]
 	} else {
@@ -127,10 +130,10 @@ func HandleRequest(ctx context.Context, evt events.KinesisEvent) error {
 	log.Printf("INFO Writing %d records to dynamo", processedRecordCount)
 
 	//dynamodb only supports batches of up to 25 items
-	for i:=0; i<processedRecordCount; i+=25 {
+	for i := 0; i < processedRecordCount; i += 25 {
 		lastRecordToProcess := processedRecordCount
 		if i+25 < processedRecordCount {
-			lastRecordToProcess = i+25
+			lastRecordToProcess = i + 25
 		}
 		nextBatch := putRequests[i:lastRecordToProcess]
 		err := doBatchWrite(ctx, ddbClient, tableName, nextBatch, lastRecordToProcess-i)

--- a/eventlogger/main.go
+++ b/eventlogger/main.go
@@ -126,9 +126,18 @@ func HandleRequest(ctx context.Context, evt events.KinesisEvent) error {
 
 	log.Printf("INFO Writing %d records to dynamo", processedRecordCount)
 
-	err := doBatchWrite(ctx, ddbClient, tableName, putRequests, processedRecordCount)
-	if err != nil {
-		log.Printf("ERROR Could not write to dynamodb: %s", err)
+	//dynamodb only supports batches of up to 25 items
+	for i:=0; i<processedRecordCount; i+=25 {
+		lastRecordToProcess := processedRecordCount
+		if i+25 < processedRecordCount {
+			lastRecordToProcess = i+25
+		}
+		nextBatch := putRequests[i:lastRecordToProcess]
+		err := doBatchWrite(ctx, ddbClient, tableName, nextBatch, lastRecordToProcess-i)
+		if err != nil {
+			log.Printf("ERROR Could not write to dynamodb: %s", err)
+			return err
+		}
 	}
 
 	if deferredError != nil {


### PR DESCRIPTION
## What does this change?

- Bugfix for event processor, Dynamodb only supports batch writes of <=25 items so split into multiple batches if we have more than 25.
- Bugfix for event processor, in some circumstances DynamoDB returns an empty set of "unprocessed records" instead of null. Don't attempt to commit the empty set or we get an error

## How to test

Deploy and monitor
